### PR TITLE
Add a missing cast for fconst_2

### DIFF
--- a/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
+++ b/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
@@ -717,6 +717,7 @@ public class JdkClassWriter extends ClassVisitor {
                 case Opcodes.LCONST_1 -> CodeBuilder::lconst_1;
                 case Opcodes.FCONST_0 -> CodeBuilder::fconst_0;
                 case Opcodes.FCONST_1 -> CodeBuilder::fconst_1;
+                case Opcodes.FCONST_2 -> CodeBuilder::fconst_2;
                 case Opcodes.DCONST_0 -> CodeBuilder::dconst_0;
                 case Opcodes.DCONST_1 -> CodeBuilder::dconst_1;
                 case Opcodes.IALOAD -> CodeBuilder::iaload;


### PR DESCRIPTION
Fixes

```
java.lang.IllegalArgumentException: Unexpected opcode: 13
	at codes.rafael.asmjdkbridge.JdkClassWriter$WritingMethodVisitor.visitInsn(JdkClassWriter.java:813)
	at net.bytebuddy.jar.asm.MethodVisitor.visitInsn(MethodVisitor.java:337)
```