### PR TITLE
Roundtrip via ClassNode

### DIFF
--- a/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassReader.java
+++ b/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassReader.java
@@ -434,8 +434,12 @@ public class JdkClassReader {
                             case CharacterRange characterRange -> characterRanges.add(characterRange);
                             case RuntimeVisibleTypeAnnotationsAttribute value -> appendCodeAnnotations(value.annotations(), true, methodVisitor, labels, localVariableAnnotations, offsetTypeAnnotations);
                             case RuntimeInvisibleTypeAnnotationsAttribute value -> appendCodeAnnotations(value.annotations(), false, methodVisitor, labels, localVariableAnnotations, offsetTypeAnnotations);
-                            case DiscontinuedInstruction.JsrInstruction value -> methodVisitor.visitJumpInsn(value.opcode().bytecode(), labels.computeIfAbsent(value.target(), _ -> new org.objectweb.asm.Label()));
-                            case DiscontinuedInstruction.RetInstruction value -> methodVisitor.visitVarInsn(value.opcode().bytecode(), value.slot());
+                            case DiscontinuedInstruction.JsrInstruction value -> methodVisitor.visitJumpInsn(
+                                (value.opcode() == Opcode.JSR_W ? Opcode.JSR : value.opcode()).bytecode(),
+                                    labels.computeIfAbsent(value.target(), _ -> new org.objectweb.asm.Label()));
+                            case DiscontinuedInstruction.RetInstruction value -> methodVisitor.visitVarInsn(
+                                (value.opcode() == Opcode.RET_W ? Opcode.RET : value.opcode()).bytecode(),
+                                    value.slot());
                             default -> throw new UnsupportedOperationException("Unknown value: " + element);
                         }
                         if (element instanceof Instruction) {

--- a/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassReader.java
+++ b/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassReader.java
@@ -153,6 +153,7 @@ public class JdkClassReader {
         classVisitor.visit(classModel.minorVersion() << 16 | classModel.majorVersion(),
                 classModel.flags().flagsMask()
                         | (classModel.findAttribute(Attributes.deprecated()).isPresent() ? Opcodes.ACC_DEPRECATED : 0)
+                        | (classModel.findAttribute(Attributes.synthetic()).isPresent() ? Opcodes.ACC_SYNTHETIC: 0)
                         | (classModel.findAttribute(Attributes.record()).isPresent() ? Opcodes.ACC_RECORD : 0),
                 classModel.thisClass().asInternalName(),
                 classModel.findAttribute(Attributes.signature()).map(signature -> signature.signature().stringValue()).orElse(null),
@@ -236,7 +237,9 @@ public class JdkClassReader {
                     }
                 });
         for (FieldModel fieldModel : classModel.fields()) {
-            FieldVisitor fieldVisitor = classVisitor.visitField(fieldModel.flags().flagsMask() | (fieldModel.findAttribute(Attributes.deprecated()).isPresent() ? Opcodes.ACC_DEPRECATED : 0),
+            FieldVisitor fieldVisitor = classVisitor.visitField(fieldModel.flags().flagsMask()
+                    | (fieldModel.findAttribute(Attributes.deprecated()).isPresent() ? Opcodes.ACC_DEPRECATED : 0)
+                    | (fieldModel.findAttribute(Attributes.synthetic()).isPresent() ? Opcodes.ACC_SYNTHETIC : 0),
                     fieldModel.fieldName().stringValue(),
                     fieldModel.fieldType().stringValue(),
                     fieldModel.findAttribute(Attributes.signature()).map(signature -> signature.signature().stringValue()).orElse(null),
@@ -250,7 +253,9 @@ public class JdkClassReader {
             }
         }
         for (MethodModel methodModel : classModel.methods()) {
-            MethodVisitor methodVisitor = classVisitor.visitMethod(methodModel.flags().flagsMask() | (methodModel.findAttribute(Attributes.deprecated()).isPresent() ? Opcodes.ACC_DEPRECATED : 0),
+            MethodVisitor methodVisitor = classVisitor.visitMethod(methodModel.flags().flagsMask()
+                    | (methodModel.findAttribute(Attributes.deprecated()).isPresent() ? Opcodes.ACC_DEPRECATED : 0)
+                    | (methodModel.findAttribute(Attributes.synthetic()).isPresent() ? Opcodes.ACC_SYNTHETIC : 0),
                     methodModel.methodName().stringValue(),
                     methodModel.methodType().stringValue(),
                     methodModel.findAttribute(Attributes.signature()).map(signature -> signature.signature().stringValue()).orElse(null),

--- a/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
+++ b/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
@@ -717,6 +717,7 @@ public class JdkClassWriter extends ClassVisitor {
                 case Opcodes.LCONST_1 -> CodeBuilder::lconst_1;
                 case Opcodes.FCONST_0 -> CodeBuilder::fconst_0;
                 case Opcodes.FCONST_1 -> CodeBuilder::fconst_1;
+                case Opcodes.FCONST_2 -> CodeBuilder::fconst_2;
                 case Opcodes.DCONST_0 -> CodeBuilder::dconst_0;
                 case Opcodes.DCONST_1 -> CodeBuilder::dconst_1;
                 case Opcodes.IALOAD -> CodeBuilder::iaload;

--- a/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
+++ b/asm-jdk-bridge/src/main/java-24/codes/rafael/asmjdkbridge/JdkClassWriter.java
@@ -388,6 +388,9 @@ public class JdkClassWriter extends ClassVisitor {
                 if (!invisibleTypeAnnotations.isEmpty()) {
                     attributes.add(RuntimeInvisibleTypeAnnotationsAttribute.of(invisibleTypeAnnotations));
                 }
+                if (signature != null) {
+                    attributes.add(SignatureAttribute.of(ClassSignature.parseFrom(signature)));
+                } 
                 recordComponents.add(RecordComponentInfo.of(name, ClassDesc.ofDescriptor(descriptor), attributes));
             }
         };


### PR DESCRIPTION
Differences found when AsmJdkReader to ClassNode to AsmJdkWriter used on ASM test classes.

a) Missing signature on Record Component
```
RoundTrip asm-test-9.7-sources\jdk14\AllStructures$RecordSubType.class via ClassNode
Comparing files ORIGINAL and RESULT
***** ORIGINAL
   16:    @Lannotations/ITUA;(v=3) : FIELD, null // invisible
   17:    RECORDCOMPONENT   // signature Ljava/util/List<Ljava/lang/String;>;
   18:    // declaration: component2 extends java.util.List<java.lang.String>
   19:    Ljava/util/List; component2
   20:    @Lannotations/VRCA;(v=5)
***** RESULT
   16:    @Lannotations/ITUA;(v=3) : FIELD, null // invisible
   17:    RECORDCOMPONENT   Ljava/util/List; component2
   18:    @Lannotations/VRCA;(v=5)
*****
```

b) Missing fconst_2
```
RoundTrip asm-test-9.7-sources\jdk3\AllInstructions.class via ClassNode
RoundTrip of asm-test-9.7-sources\jdk3\AllInstructions.class via ClassNode was unsuccessful
    java.lang.IllegalArgumentException: Unexpected opcode: 13
```

c) Missing synthetic access code; synthetic is an Attribute before V1_5
```
RoundTrip asm-test-9.7-sources\jdk3\AllStructures$1.class via ClassNode
Comparing files ORIGINAL and RESULT
***** ORIGINAL
   10:  
   11:    // access flags 0x1012
   12:    private final synthetic Ljdk3/AllStructures; this$0
   13:  
***** RESULT
   10:  
   11:    // access flags 0x12
   12:    private final Ljdk3/AllStructures; this$0
   13:  
*****
```

d) In reader translate jsr_w to jsr and ret_w to ret ; similar to goto_w to goto
```
RoundTrip asm-test-9.7-sources\jdk3\LargeMethod.class via ClassNode
RoundTrip of asm-test-9.7-sources\jdk3\LargeMethod.class via ClassNode was unsuccessful
    java.lang.IllegalArgumentException: Unexpected opcode: 201
```


